### PR TITLE
gkrellm.rb: fixed curry'd inreplace.

### DIFF
--- a/gkrellm.rb
+++ b/gkrellm.rb
@@ -31,9 +31,9 @@ class Gkrellm < Formula
     inreplace 'Makefile', '$(PREFIX)', prefix
     inreplace 'src/gkrellm.h' do |s|
       s.gsub! '/usr/local/share/gkrellm2/themes', "#{share}/gkrellm2/themes"
-      s.gsub! 'src/gkrellm.h', '/usr/share/gkrellm2/themes', "#{share}/gkrellm2/themes"
-      s.gsub! 'src/gkrellm.h', '/usr/local/lib/gkrellm2/plugins', "#{libexec}/gkrellm2/plugins"
-      s.gsub! 'src/gkrellm.h', '/usr/lib/gkrellm2/plugins', "#{libexec}/gkrellm2/plugins"
+      s.gsub! '/usr/share/gkrellm2/themes', "#{share}/gkrellm2/themes"
+      s.gsub! '/usr/local/lib/gkrellm2/plugins', "#{libexec}/gkrellm2/plugins"
+      s.gsub! '/usr/lib/gkrellm2/plugins', "#{libexec}/gkrellm2/plugins"
     end
 
     system "make", "darwin9"

--- a/gkrellm.rb
+++ b/gkrellm.rb
@@ -16,6 +16,7 @@ class Gkrellm < Formula
   depends_on 'glib'
   depends_on 'gtk+'
   depends_on 'pango'
+  depends_on 'openssl'
 
   patch :p0 do
     url "https://trac.macports.org/export/115088/trunk/dports/sysutils/gkrellm/files/207a0519ac73290ba65b6e5f7446549a2a66f5d2.patch"


### PR DESCRIPTION
Removed first argument from 3 gsub calls to clear up build issue.