### PR TITLE
libsigc++ dependent formulas need C++11 support

### DIFF
--- a/gobby.rb
+++ b/gobby.rb
@@ -3,7 +3,7 @@ class Gobby < Formula
   homepage "http://gobby.0x539.de"
   url "http://releases.0x539.de/gobby/gobby-0.5.0.tar.gz"
   sha256 "8ceb3598d27cfccdf9c9889b781c4c5c8e1731ca6beb183f5d4555644c06bd98"
-  revision 1
+  revision 2
 
   head "git://git.0x539.de/git/gobby.git"
 
@@ -30,7 +30,10 @@ class Gobby < Formula
   depends_on "hicolor-icon-theme"
   depends_on "libinfinity"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--with-gtk3"
     system "make", "install"

--- a/gsmartcontrol.rb
+++ b/gsmartcontrol.rb
@@ -3,7 +3,7 @@ class Gsmartcontrol < Formula
   homepage "http://gsmartcontrol.sourceforge.net/home/index.php"
   url "https://downloads.sourceforge.net/project/gsmartcontrol/0.8.7/gsmartcontrol-0.8.7.tar.bz2"
   sha256 "708fa803243abb852ed52050fc82cd3592a798c02743342441996e77f19ffec6"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "655cb81fca643ef4e8f0a049f528a03418f1592c78d3a190e5225dffb4ba6860" => :yosemite
@@ -16,11 +16,14 @@ class Gsmartcontrol < Formula
   depends_on "gtkmm"
   depends_on "pcre"
 
+  needs :cxx11
+
   # Fix bad includes with gtkmm-2.24.3
   # Check if this is still needed with new versions of gsmartcontrol and gtkmm
   patch :DATA
 
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make"

--- a/gtksourceviewmm.rb
+++ b/gtksourceviewmm.rb
@@ -3,7 +3,7 @@ class Gtksourceviewmm < Formula
   homepage "https://developer.gnome.org/gtksourceviewmm/"
   url "https://download.gnome.org/sources/gtksourceviewmm/2.10/gtksourceviewmm-2.10.3.tar.xz"
   sha256 "0000df1b582d7be2e412020c5d748f21c0e6e5074c6b2ca8529985e70479375b"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "3d8566e86cece40dc4a6b04c2c98918d536b9e4cc7afa77a97b607488913e02c" => :yosemite
@@ -15,7 +15,10 @@ class Gtksourceviewmm < Formula
   depends_on "pkg-config" => :build
   depends_on "gtkmm"
 
+  needs :cxx11
+
   def install
+    ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -120,7 +123,7 @@ class Gtksourceviewmm < Formula
       -lpangomm-1.4
       -lsigc-2.0
     ]
-    system ENV.cxx, "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/inkscape.rb
+++ b/inkscape.rb
@@ -4,7 +4,7 @@ class Inkscape < Formula
   url "https://inkscape.org/en/gallery/item/3854/inkscape-0.91.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/i/inkscape/inkscape_0.91.orig.tar.gz"
   sha256 "2ca3cfbc8db53e4a4f20650bf50c7ce692a88dcbf41ebc0c92cd24e46500db20"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "b8178793aea18bcd80aa660949a8fd6e8e13f9668b93973f15a8ab3ffe9caea6" => :yosemite
@@ -35,16 +35,16 @@ class Inkscape < Formula
   depends_on "pango"
   depends_on "popt"
 
+  needs :cxx11
+
   if MacOS.version < :mavericks
     fails_with :clang do
       cause "inkscape's dependencies will be built with libstdc++ and fail to link."
     end
   end
 
-  needs :cxx11 if MacOS.version >= :mavericks
-
   def install
-    ENV.cxx11 if MacOS.version >= :mavericks
+    ENV.cxx11
     ENV.append "LDFLAGS", "-liconv"
 
     args = %W[


### PR DESCRIPTION
Recently all C++ gnome packages introduced a mandatory C++11 requirement,
which implies that all packages depending on these also need to have
the same requirement.

This PR add revision bumps as well as makes the necessary changes for
C++ compiler support