### PR TITLE
rdesktop: Add option to build with smartcard support.

### DIFF
--- a/rdesktop.rb
+++ b/rdesktop.rb
@@ -28,11 +28,11 @@ class Rdesktop < Formula
             "--with-openssl=#{Formula["openssl"].opt_prefix}",
             "--x-includes=#{MacOS::X11.include}",
             "--x-libraries=#{MacOS::X11.lib}"]
-    if build.with? "smartcard"
-        args << "--enable-smartcard"
-    else
-        args << "--disable-smartcard"
-    end
+  if build.with? "smartcard"
+    args << "--enable-smartcard"
+  else
+    args << "--disable-smartcard"
+  end
     system "./configure", *args
     system "make", "install"
   end

--- a/rdesktop.rb
+++ b/rdesktop.rb
@@ -13,9 +13,11 @@ class Rdesktop < Formula
   depends_on "openssl"
   depends_on :x11
 
+  option "with-smartcard", "Build with Smart Card Support"
+
   # Note: The patch below is meant to remove the reference to the
   # undefined symbol SCARD_CTL_CODE. Since we are compiling with
-  # --disable-smartcard, we don't need it anyway (and it should
+  # --disable-smartcard (by default), we don't need it anyway (and it should
   # probably have been #ifdefed in the original code).
   # upstream bug report: https://sourceforge.net/p/rdesktop/bugs/352/
   patch :DATA
@@ -23,10 +25,14 @@ class Rdesktop < Formula
   def install
     args = ["--prefix=#{prefix}",
             "--disable-credssp",
-            "--disable-smartcard", # disable temporally before upstream fix
             "--with-openssl=#{Formula["openssl"].opt_prefix}",
             "--x-includes=#{MacOS::X11.include}",
             "--x-libraries=#{MacOS::X11.lib}"]
+    if build.with? "smartcard"
+        args << "--enable-smartcard"
+    else
+        args << "--disable-smartcard"
+    end
     system "./configure", *args
     system "make", "install"
   end


### PR DESCRIPTION
Add option (--with-smartcard) to build with smartcard support.  Defaults to disabling smartcard support.

Test built on 10.8.5 and 10.11.3. Runs on 10.11.3 and uses USB smartcard for authentication to Windows Server.