### PR TITLE
chezscheme 9.4 (new formula)

### DIFF
--- a/chezscheme.rb
+++ b/chezscheme.rb
@@ -1,0 +1,27 @@
+class Chezscheme < Formula
+  desc "Chez Scheme"
+  homepage "https://cisco.github.io/ChezScheme/"
+  url "https://github.com/cisco/ChezScheme/archive/v9.4.tar.gz"
+  sha256 "9f4e6fe737300878c3c9ca6ed09ed97fc2edbf40e4cf37bd61f48a27f5adf952"
+
+  depends_on :x11 => :build
+
+  conflicts_with "mit-scheme", :because => "both install `scheme` binaries"
+
+  def install
+    system "./configure", "--installprefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"hello.ss").write <<-EOS.undent
+      (display "Hello, World!") (newline)
+    EOS
+
+    expected = <<-EOS.undent
+      Hello, World!
+    EOS
+
+    assert_equal expected, shell_output("#{bin}/scheme --script hello.ss")
+  end
+end

--- a/chezscheme.rb
+++ b/chezscheme.rb
@@ -6,10 +6,11 @@ class Chezscheme < Formula
 
   depends_on :x11 => :build
 
-  conflicts_with "mit-scheme", :because => "both install `scheme` binaries"
-
   def install
-    system "./configure", "--installprefix=#{prefix}"
+    system "./configure",
+              "--installprefix=#{prefix}",
+              "--threads",
+              "--installschemename=chez"
     system "make", "install"
   end
 
@@ -22,6 +23,6 @@ class Chezscheme < Formula
       Hello, World!
     EOS
 
-    assert_equal expected, shell_output("#{bin}/scheme --script hello.ss")
+    assert_equal expected, shell_output("#{bin}/chez --script hello.ss")
   end
 end


### PR DESCRIPTION
Chez Scheme is a compiler and run-time system for the language of the
Revised6 Report on Scheme (R6RS), with numerous extensions. The compiler
generates native code for each target processor, with support for x86,
x86_64, and 32-bit PowerPC architectures.