### PR TITLE
curlftpfs: fix head url

### DIFF
--- a/curlftpfs.rb
+++ b/curlftpfs.rb
@@ -3,7 +3,7 @@ class Curlftpfs < Formula
   url "https://downloads.sourceforge.net/project/curlftpfs/curlftpfs/0.9.2/curlftpfs-0.9.2.tar.gz"
   sha256 "4eb44739c7078ba0edde177bdd266c4cfb7c621075f47f64c85a06b12b3c6958"
 
-  head "https://github.com/rfw/curlftpfs.git"
+  head ":pserver:anonymous:@curlftpfs.cvs.sourceforge.net:/cvsroot/curlftpfs", :using => :cvs
 
   depends_on "pkg-config" => :build
   depends_on "autoconf" => :build


### PR DESCRIPTION
https://github.com/rfw/curlftpfs.git no longer exists