### PR TITLE
openmotif: fix VendorShell reference for XQuartz 2.7.9 and 2.7.10

### DIFF
--- a/openmotif.rb
+++ b/openmotif.rb
@@ -121,3 +121,44 @@ index e3f56bd..d056e03 100644
  #include <Xm/Xm.h>
  #include "wsm.h"
  #include "wsmDebug.h"
+
+
+diff --git a/lib/Xm/VendorS.c b/lib/Xm/VendorS.c
+index b5b5a24..cbd0967 100644
+--- a/lib/Xm/VendorS.c
++++ b/lib/Xm/VendorS.c
+@@ -292,6 +292,25 @@ static unsigned short destroy_list_cnt ;
+ static Display * _XmDisplayHandle = NULL ;
+ static XtErrorMsgHandler previousWarningHandler = NULL;
+ 
++
++
++#if defined(__APPLE__)
++/* Hack necessary to handle Apple two-level namespaces */
++extern WidgetClass vendorShellWidgetClass; /* from Xt/Vendor.c */
++extern VendorShellClassRec _XmVendorShellClassRec;
++#define vendorShellClassRec _XmVendorShellClassRec
++
++__attribute__((constructor))
++static void __VendorShellHack(void)
++{
++    vendorShellWidgetClass = (WidgetClass)(&_XmVendorShellClassRec);
++    transientShellWidgetClass->core_class.superclass = vendorShellWidgetClass;
++    topLevelShellWidgetClass->core_class.superclass = vendorShellWidgetClass;
++}
++#endif
++
++
++
+ /***************************************************************************
+  *
+  * Vendor shell class record
+@@ -506,6 +525,8 @@ VendorShellClassRec vendorShellClassRec = {
+     }                            
+ };	   
+ 
++#undef vendorShellClassRec
++
+ externaldef(vendorshellwidgetclass) WidgetClass 
+   vendorShellWidgetClass = (WidgetClass) (&vendorShellClassRec);
+ 


### PR DESCRIPTION
The XQuartz 2.7.9 and 2.7.10 releases changed the libXt dylib to be built without -flat_namespace.  This breaks Xt-based widget libraries that overload VendorShell by using ELF-style or static-linking-style tricks that expect to be able to replace a symbol just by using it in a "higher-level" library.  

This change is based on the change that the XQuartz maintainer did to libXaw, which does the same trick that Motif does.

It lets nedit and grace run again with XQuartz 2.7.9 and 2.7.10.

This fixes #255 
